### PR TITLE
fix: NoData の範囲を透明にする

### DIFF
--- a/csmap/process.py
+++ b/csmap/process.py
@@ -52,6 +52,18 @@ def csmap(dem: np.ndarray, params: CsmapParams) -> np.ndarray:
     return blend
 
 
+def _read_chunk(dem, window) -> np.ndarray:
+    """NoDataをNaNとして読み込む。
+
+    整数型のDEMは NaN を保持できないため float32 に昇格させる。
+    float64 のDEMは精度を落とさないようそのまま扱う。
+    """
+    chunk = dem.read(1, window=window, masked=True)
+    if not np.issubdtype(chunk.dtype, np.floating):
+        chunk = chunk.astype("float32")
+    return chunk.filled(np.nan)
+
+
 def _process_chunk(
     chunk: np.ndarray,
     dst: rasterio.io.DatasetWriter,
@@ -73,6 +85,15 @@ def _process_chunk(
             (params.gf_size + params.gf_sigma) // 2
         ),
     ]  # shape = (4, chunk_size - margin, chunk_size - margin)
+
+    # NoData(NaN)の位置を透明にする。
+    # 削られた縁の幅は入力chunkと出力の形状差から求めるので、
+    # パディングやフィルタサイズの実装が変わっても追従する。
+    out_h, out_w = csmap_chunk_margin_removed.shape[1:]
+    off_y = (chunk.shape[0] - out_h) // 2
+    off_x = (chunk.shape[1] - out_w) // 2
+    nodata_mask = np.isnan(chunk)[off_y : off_y + out_h, off_x : off_x + out_w]
+    csmap_chunk_margin_removed[3, nodata_mask] = 0
 
     if lock is None:
         dst.write(
@@ -142,7 +163,9 @@ def process(
                         if y + chunk_csmap_size > out_height:
                             write_size_y = out_height - y
 
-                        chunk = dem.read(1, window=Window(x, y, chunk_size, chunk_size))
+                        chunk = _read_chunk(
+                            dem, Window(x, y, chunk_size, chunk_size)
+                        )
                         _process_chunk(
                             chunk,
                             dst,
@@ -166,8 +189,8 @@ def process(
                             if y + chunk_csmap_size > out_height:
                                 write_size_y = out_height - y
 
-                            chunk = dem.read(
-                                1, window=Window(x, y, chunk_size, chunk_size)
+                            chunk = _read_chunk(
+                                dem, Window(x, y, chunk_size, chunk_size)
                             )
                             executor.submit(
                                 _process_chunk,

--- a/tests/test_nodata.py
+++ b/tests/test_nodata.py
@@ -1,0 +1,140 @@
+import os
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from csmap.process import process, CsmapParams
+
+
+PARAMS = CsmapParams(
+    gf_size=12,
+    gf_sigma=3,
+    curvature_size=1,
+    height_scale=[0, 1000],
+    slope_scale=[0, 1.5],
+    curvature_scale=[-0.1, 0.1],
+)
+
+
+def _make_dem(path: str, dtype: str, nodata, size: int = 600):
+    """中央に山、周囲がNoData の DEM を生成する
+
+    Returns:
+        NoData 画素の割合
+    """
+    yy, xx = np.mgrid[0:size, 0:size]
+    r = np.sqrt((yy - size / 2) ** 2 + (xx - size / 2) ** 2)
+    elev = 300 * np.exp(-((r / (size * 0.18)) ** 2)) + 20 * np.sin(xx / 9) * np.exp(
+        -((r / (size * 0.22)) ** 2)
+    )
+
+    hole = r > size * 0.36  # 外周をNoDataにする
+    if np.issubdtype(np.dtype(dtype), np.integer):
+        arr = np.clip(elev, 0, 3000).astype(dtype)
+    else:
+        arr = elev.astype(dtype)
+    arr[hole] = nodata
+
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype=dtype,
+        nodata=nodata,
+        transform=from_origin(139.0, 35.0, 0.5, 0.5),
+        crs="EPSG:3857",
+    ) as dst:
+        dst.write(arr, 1)
+
+    return hole.mean()
+
+
+@pytest.mark.parametrize(
+    "dtype,nodata",
+    [
+        ("float32", -9999.0),
+        ("float32", float("nan")),
+        ("float32", 1.70141e38),  # 航空レーザ測量DEMで使われる値
+        ("int16", -9999),
+        ("int32", -32768),
+        ("uint16", 65535),
+    ],
+)
+def test_nodata_is_transparent(tmp_path, dtype, nodata):
+    """NoData の範囲が透明になることをテスト
+
+    dtype と NoData 値の組み合わせによらず透明化されること。
+    整数型の DEM は NaN を保持できないため、内部で float に昇格する必要がある。
+    """
+    dem_path = str(tmp_path / f"dem_{dtype}.tif")
+    nodata_ratio = _make_dem(dem_path, dtype, nodata)
+
+    out_path = str(tmp_path / f"csmap_{dtype}.tif")
+    process(
+        input_dem_path=dem_path,
+        output_path=out_path,
+        chunk_size=256,
+        params=PARAMS,
+        max_workers=1,
+    )
+
+    alpha = rasterio.open(out_path).read(4)
+    transparent_ratio = (alpha == 0).mean()
+
+    # 縁が削られる分だけ NoData 比率とはわずかにずれるため許容幅を持たせる
+    assert transparent_ratio == pytest.approx(nodata_ratio, abs=0.05), (
+        f"{dtype}/{nodata}: 透明={transparent_ratio:.3f} "
+        f"期待={nodata_ratio:.3f}"
+    )
+
+
+def test_nodata_transparent_by_worker(tmp_path):
+    """並列処理でも NoData の透明化が一致することをテスト"""
+    dem_path = str(tmp_path / "dem.tif")
+    _make_dem(dem_path, "float32", -9999.0)
+
+    outs = []
+    for workers in (1, 2):
+        out_path = str(tmp_path / f"csmap_w{workers}.tif")
+        process(
+            input_dem_path=dem_path,
+            output_path=out_path,
+            chunk_size=256,
+            params=PARAMS,
+            max_workers=workers,
+        )
+        outs.append(rasterio.open(out_path).read([1, 2, 3, 4]))
+
+    assert outs[0].shape == outs[1].shape
+    assert (outs[0] == outs[1]).all()
+
+
+def test_no_nodata_declared_stays_opaque(tmp_path):
+    """NoData が宣言されていない DEM では全て不透明のままであることをテスト
+
+    透明化は NoData 宣言を根拠にしているため、宣言が無ければ何も起きない。
+    既存の挙動が変わらないことの確認でもある。
+    """
+    dem_path = str(tmp_path / "dem_no_nodata.tif")
+    _make_dem(dem_path, "float32", -9999.0)
+
+    # NoData 宣言だけを外す（画素値は変えない）
+    with rasterio.open(dem_path, "r+") as dst:
+        dst.nodata = None
+
+    out_path = str(tmp_path / "csmap_no_nodata.tif")
+    process(
+        input_dem_path=dem_path,
+        output_path=out_path,
+        chunk_size=256,
+        params=PARAMS,
+        max_workers=1,
+    )
+
+    alpha = rasterio.open(out_path).read(4)
+    assert (alpha == 255).all()


### PR DESCRIPTION
## 症状

NoData が設定された DEM を入力すると、データの無い範囲（海・範囲外・欠測域）が
透明にならず地形として描画されます。地図タイルとして配信すると下のレイヤが隠れてしまいます。

![NoData comparison](https://raw.githubusercontent.com/shiwaku/csmap-tile-pipeline/main/docs/images/nodata-comparison.png)

左: 修正前 / 右: 修正後（市松模様が透明部分）。入力DEM・パラメータは同一です。

## 原因

DEM の読み込みが NoData 宣言を参照していないため、NoData の値
（この例では `1.70141e+38`）が標高の実測値として計算に入っていました。

```python
chunk = dem.read(1, window=Window(x, y, chunk_size, chunk_size))
```

`np.isnan(1.70141e+38)` は `False` なので、後段で位置を特定することもできません。

## 変更内容

`csmap/process.py` のみ、26行です。

**1. `_read_chunk()` を追加し、NoData を NaN として読む**

```python
chunk = dem.read(1, window=window, masked=True)
if not np.issubdtype(chunk.dtype, np.floating):
    chunk = chunk.astype("float32")
return chunk.filled(np.nan)
```

整数型の DEM は NaN を保持できないため float32 に昇格させています。
これが無いと `TypeError: Cannot convert fill_value nan to dtype int16` になります
（SRTM や ASTER GDEM は Int16 です）。float64 の DEM は精度を落とさずそのまま扱います。

**2. `_process_chunk()` で NaN の位置のアルファを 0 にする**

```python
out_h, out_w = csmap_chunk_margin_removed.shape[1:]
off_y = (chunk.shape[0] - out_h) // 2
off_x = (chunk.shape[1] - out_w) // 2
nodata_mask = np.isnan(chunk)[off_y : off_y + out_h, off_x : off_x + out_w]
csmap_chunk_margin_removed[3, nodata_mask] = 0
```

削られる縁の幅は入力 `chunk` と出力の形状差から求めているので、
パディングやフィルタサイズの実装が変わっても追従します。

## テスト

`tests/test_nodata.py` を追加しました。フィクスチャは増やさず、テスト内で合成DEMを生成します。

| テスト | 内容 |
|---|---|
| `test_nodata_is_transparent` | dtype/NoData値の6通り（float32の−9999/NaN/1.70141e+38、int16/int32/uint16）で、透明画素の割合が入力のNoData比率と一致すること |
| `test_nodata_transparent_by_worker` | 並列処理でも結果が一致すること |
| `test_no_nodata_declared_stays_opaque` | NoData宣言の無いDEMでは全て不透明のままであること |

```
修正前(v0.1.4): 6 failed, 2 passed
修正後:         8 passed（既存3件と合わせて 11 passed）
```

既存の3件も通ります。

## 実データでの確認

東京都の点群由来 DEM（0.25m / Float32 / `NoData=1.70141e+38`、
全画素の 29.8% が NoData / 11,203 x 14,780）:

| | 出力の透明率 |
|---|---|
| v0.1.4 | 0.00% |
| 本PR | **29.63%** |

入力の NoData 比率とほぼ一致します。

性能（float32 1200x1200 / chunk 1024）:

| | 所要 | 最大メモリ |
|---|---|---|
| v0.1.4 | 0.99秒 | 220.6MB |
| 本PR | 0.66秒 | 226.0MB (+2.5%) |

`masked=True` のオーバーヘッドを懸念していましたが、実測では問題ありませんでした。

## 既存挙動への影響

**NoData が宣言された DEM では出力が変わります。** これまで不透明だった範囲が透明になります。

- NoData 宣言の無い DEM では出力は変わりません（既存テスト3件が通ることで確認）
- 現状の「NoData も地形として描画される」挙動に依存している利用者がいる場合、影響を受けます

## 質問

NoData 宣言の無い DEM では、この修正でも透明化されません。
`--src-nodata` のような指定を設けるべきか、仕様として README に明記するにとどめるか、
ご判断をうかがえればと思います。必要であれば追加で対応します。

## 補足

CS立体図のラスタータイルを作る一連の手順を以下にまとめており、
本件の調査経緯と検証結果もそこに記録しています。

https://github.com/shiwaku/csmap-tile-pipeline